### PR TITLE
Feature/counter clockwise

### DIFF
--- a/Cirque/Classes/Cirque.swift
+++ b/Cirque/Classes/Cirque.swift
@@ -24,6 +24,7 @@ public class CirqueView : UIView {
     public var transitionSize: CGFloat = 0.05
     public var stepSize: CGFloat = 0.1
     public var lineWidth: CGFloat = 5
+    public var isClockwise: Bool = true
     
     fileprivate var circleRadius : CGFloat {
         return (self.bounds.size.width - lineWidth)/2
@@ -36,8 +37,8 @@ public class CirqueView : UIView {
     fileprivate func drawGradient(_ fromColor: UIColor, toColor: UIColor, from startPosition: CGFloat, with relativeSize: CGFloat) {
         
         let zeroAngle = CGFloat(-90.0).degreesToRadians
-        let startAngle    = zeroAngle + (CGFloat(360).degreesToRadians * startPosition)
-        let finalEndAngle = zeroAngle + (CGFloat(360).degreesToRadians * (startPosition + max(relativeSize, 0)))
+        let startAngle    = zeroAngle + (clockwise: isClockwise, (CGFloat(360).degreesToRadians * startPosition))
+        let finalEndAngle = zeroAngle + (clockwise: isClockwise, (CGFloat(360).degreesToRadians * (startPosition + max(relativeSize, 0))))
         let totalGradientSize = abs(finalEndAngle - startAngle)
         var runningStartAngle = startAngle
         
@@ -49,7 +50,7 @@ public class CirqueView : UIView {
         
         for stepFraction in stride(from: CGFloat(0), through: 1.0, by: stepSize) {
             
-            let endAngle = (stepFraction * totalGradientSize) + startAngle
+            let endAngle = startAngle + (clockwise: isClockwise, rhs:(stepFraction * totalGradientSize))
             
             let newRed   = startColorComponents.red   + (finalColorComponents.red   - startColorComponents.red)   * stepFraction
             let newGreen = startColorComponents.green + (finalColorComponents.green - startColorComponents.green) * stepFraction
@@ -59,7 +60,7 @@ public class CirqueView : UIView {
             
             progressColor.set()
             
-            processPath.addArc(withCenter: circleCenter, radius: circleRadius, startAngle: runningStartAngle, endAngle: endAngle, clockwise: true)
+            processPath.addArc(withCenter: circleCenter, radius: circleRadius, startAngle: runningStartAngle, endAngle: endAngle, clockwise: isClockwise)
             processPath.stroke()
             processPath.removeAllPoints()
             
@@ -70,14 +71,14 @@ public class CirqueView : UIView {
     
     fileprivate func drawSolid(_ color: UIColor, from startPosition: CGFloat, with relativeSize: CGFloat) {
         let zeroAngle = CGFloat(-90.0).degreesToRadians
-        let startAngle    = zeroAngle + (CGFloat(360).degreesToRadians * startPosition)
-        let finalEndAngle = zeroAngle + (CGFloat(360).degreesToRadians * (startPosition + max(relativeSize, 0)))
+        let startAngle    = zeroAngle + (clockwise: isClockwise, (CGFloat(360).degreesToRadians * startPosition))
+        let finalEndAngle = zeroAngle + (clockwise: isClockwise, (CGFloat(360).degreesToRadians * (startPosition + max(relativeSize, 0))))
         let processPath = UIBezierPath()
         processPath.lineWidth = lineWidth
         
         color.set()
         
-        processPath.addArc(withCenter: circleCenter, radius: circleRadius, startAngle: startAngle, endAngle: finalEndAngle, clockwise: true)
+        processPath.addArc(withCenter: circleCenter, radius: circleRadius, startAngle: startAngle, endAngle: finalEndAngle, clockwise: isClockwise)
         processPath.stroke()
         processPath.removeAllPoints()
     }

--- a/Cirque/Classes/Cirque.swift
+++ b/Cirque/Classes/Cirque.swift
@@ -89,14 +89,14 @@ public class CirqueView : UIView {
         
         let context = UIGraphicsGetCurrentContext()
         
-        // Cleaer any previous drawings
+        // Clear any previous drawings
         context?.clear(rect)
         
         var start: CGFloat = 0.0 // Start of the the stroke in radians
         var size: CGFloat = 0.0 // Size (or length) of the stroke in percent
         let overlapSize: CGFloat = 0.001 // How much to backtrack before drawing to ensure that there are no gaps between stroke elements
         
-        // If there is jus one data point, just draw simple solig stroke
+        // If there is just one data point, just draw simple solid stroke
         guard dataPoints.count > 1 else {
             drawSolid(dataPoints[0].color, from: start, with: CGFloat(dataPoints[0].value))
             return

--- a/Cirque/Classes/FloatingPoint+Utility.swift
+++ b/Cirque/Classes/FloatingPoint+Utility.swift
@@ -12,3 +12,9 @@ public extension FloatingPoint {
     var degreesToRadians: Self { return self * .pi / 180 }
     var radiansToDegrees: Self { return self * 180 / .pi }
 }
+
+public extension CGFloat {
+    static func +(lhs: CGFloat, rhs: (clockwise: Bool, _: CGFloat)) -> CGFloat {
+        return rhs.clockwise ? lhs + rhs.1 : lhs - rhs.1
+    }
+}


### PR DESCRIPTION
This pull request will allow the stroke to progress counter-clockwise along a path. When calculating the start and final angles in `drawGradient()` and `drawSolid()`, a quick overload of the + operator on CGFloat lets us add or subtract based on the `isClockwise: Bool` property. In both methods, the property is also used when calling `processPath.addArc()`.

- Added public isClockwise property
- Added CGFloat extension
- Fixed small grammatical errors in comments

The idea behind overloading the operator on CGFloat is to allow the code to remain similar in simplicity and brevity. Rather use one extension instead of adding more than a dozen lines of repetitive conditionals.